### PR TITLE
feat(auth/error): allow uri redirection upon errors

### DIFF
--- a/app/controllers/auth/coauth_controller.rb
+++ b/app/controllers/auth/coauth_controller.rb
@@ -4,6 +4,8 @@ require 'securerandom'
 require 'addressable'
 
 module Auth
+    class AuthErrorRedirect < StandardError; end
+
     class CoauthController < ActionController::Base
         include UserHelper
         include CurrentAuthorityHelper
@@ -12,6 +14,7 @@ module Auth
         Rails.application.config.force_ssl = Rails.env.production? && (ENV['COAUTH_NO_SSL'].nil? || ENV['COAUTH_NO_SSL'] == 'false')
         USE_SSL = Rails.application.config.force_ssl
 
+        rescue_from StandardError::AuthErrorRedirect(e), with: :error_redirect(e)
 
         def success_path
             '/login_success.html'
@@ -69,6 +72,10 @@ module Auth
             }
             value[:secure] = USE_SSL
             cookies.encrypted[:continue] = value
+        end
+
+        def error_redirect(exception)
+            redirect_to exception.message
         end
     end
 end

--- a/app/controllers/auth/coauth_controller.rb
+++ b/app/controllers/auth/coauth_controller.rb
@@ -14,7 +14,7 @@ module Auth
         Rails.application.config.force_ssl = Rails.env.production? && (ENV['COAUTH_NO_SSL'].nil? || ENV['COAUTH_NO_SSL'] == 'false')
         USE_SSL = Rails.application.config.force_ssl
 
-        rescue_from StandardError::AuthErrorRedirect(e), with: :error_redirect(e)
+        rescue_from AuthErrorRedirect, with: :error_redirect
 
         def success_path
             '/login_success.html'


### PR DESCRIPTION
Allow ruby-engine to redirect to a generic or custom page upon auth errors with:

`raise ::Auth::AuthErrorRedirect.new('/error_page.html')`

Tested OK in a UAT environment with o365-engine