### PR TITLE
fix(oauth/strat): 500 on GET

### DIFF
--- a/app/models/adfs_strat.rb
+++ b/app/models/adfs_strat.rb
@@ -51,11 +51,12 @@ class AdfsStrat < CouchbaseOrm::Base
         raise 'bad type' unless type.to_s == self.class.design_document
     end
 
-    def serializable_hash(**options)
+    def serializable_hash(options = {}, **opts)
         options = {
-            methods: :type
+          methods: :type
         }.merge!(options)
-        super(**options)
+        options.merge!(opts)
+        super(options)
     end
 
 

--- a/app/models/ldap_strat.rb
+++ b/app/models/ldap_strat.rb
@@ -27,11 +27,12 @@ class LdapStrat < CouchbaseOrm::Base
         raise 'bad type' unless type.to_s == self.class.design_document
     end
 
-    def serializable_hash(**options)
+    def serializable_hash(options = {}, **opts)
         options = {
-            methods: :type
+          methods: :type
         }.merge!(options)
-        super(**options)
+        options.merge!(opts)
+        super(options)
     end
 
 

--- a/app/models/oauth_strat.rb
+++ b/app/models/oauth_strat.rb
@@ -30,11 +30,12 @@ class OauthStrat < CouchbaseOrm::Base
         raise 'bad type' unless type.to_s == self.class.design_document
     end
 
-    def serializable_hash(**options)
+    def serializable_hash(options = {}, **opts)
         options = {
-            methods: :type
+          methods: :type
         }.merge!(options)
-        super(**options)
+        options.merge!(opts)
+        super(options)
     end
 
 


### PR DESCRIPTION
Attempt to fix GET 
/auth/api/authsources?authority_id=sgrp-xxxx&offset=0

resulting in 500
ArgumentError (wrong number of arguments (given 1, expected 0)): at https://github.com/QuayPay/coauth/blob/couchbase-orm/app/models/oauth_strat.rb#L33

This may have been caused by mckinsey-engine using Rails 6, following security updates 